### PR TITLE
Update `require` statement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ ways to do this:
 Put this into your `.rubocop.yml`.
 
 ```yaml
-require: rubocop-performance
+AllCops:
+  Require: rubocop-performance
 ```
 
 Now you can run `rubocop` and it will automatically load the RuboCop Performance


### PR DESCRIPTION
Adding `require: rubocop-performance` on top of your rubocop yml will throw an exception:
```
Error running RuboCop Error: cannot load such file -- rubocop-performance ../2.5.0/rubygems/core_ext/kernel_require.rb:54:in require
```
The solution is to nest it under `AllCops`, the [docs](https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md#includingexcluding-files) actually suggest that. Keys like `Include`/`Exclude` are all capitalized, so why not capitalize `require` as well?

-----------------

Before submitting the PR make sure the following are checked:

* [ ] Wrote [good commit messages][1].
* [ ] Commit message starts with `[Fix #issue-number]` (if the related issue exists).
* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Added an entry to the [Changelog](https://github.com/rubocop-hq/rubocop-performance/blob/master/CHANGELOG.md) if the new code introduces user-observable changes. See [changelog entry format](https://github.com/rubocop-hq/rubocop-performance/blob/master/CONTRIBUTING.md#changelog-entry-format).
* [x] The PR relates to *only* one subject with a clear title
  and description in grammatically correct, complete sentences.
* [ ] Run `bundle exec rake default`. It executes all tests and RuboCop for itself, and generates the documentation.

[1]: https://chris.beams.io/posts/git-commit/
